### PR TITLE
fix: CVE-2021-29425 and license URL

### DIFF
--- a/seed-me/build.gradle
+++ b/seed-me/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "org.grails:grails-dependencies"
     // implementation 'javax.servlet:javax.servlet-api:3.1.0'
     implementation "com.h2database:h2"
-    api 'org.apache.commons:commons-io:1.3.2'
+    api 'commons-io:commons-io:2.20.0'
     api 'org.yaml:snakeyaml:2.3'
     console "org.grails:grails-console"
     api "org.grails:grails-plugin-domain-class"
@@ -80,7 +80,7 @@ publishing {
                     licenses {
                         license {
                             name 'The Apache Software License, Version 2.0'
-                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                             distribution 'repo'
                         }
                     }


### PR DESCRIPTION
Updated commons-io to version 2.20.0 to close a security issue.
Updated license URL